### PR TITLE
refactor: task 5 admin page and sessions

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -54,8 +54,8 @@ app.use(session({
         //maxAge: 5 * 60 * 60 * 24 * 1000, // 5 days
         /* The `secure: false` option within the `session` middleware configuration is used to specify
         whether the session cookie should be set with the `Secure` attribute or not. */
-        // TODO: probably should be true in production if we use http
-        secure: false
+        // TODO: probably should be true in production if we use https
+        secure: process.env.HTTPS === "true",
     },
 }));
 

--- a/api/index.js
+++ b/api/index.js
@@ -55,7 +55,7 @@ app.use(session({
         //maxAge: 5 * 60 * 60 * 24 * 1000, // 5 days
         /* The `secure: false` option within the `session` middleware configuration is used to specify
         whether the session cookie should be set with the `Secure` attribute or not. */
-        // TODO: probably should be true in production if we use https
+        // SHOULD be true in production if we use https (safe) otherwise false for dev or non-https environments
         secure: process.env.HTTPS === "true",
     },
 }));

--- a/api/index.js
+++ b/api/index.js
@@ -35,11 +35,13 @@ app.use(session({
     /* The `secret: 'my-secret-key'` in the `session` middleware configuration is setting a secret key
     used to sign the session ID cookie. This secret key is used to encrypt the session data stored
     on the client-side and prevent tampering or unauthorized access to the session data. */
-    secret: 'my-secret-key',
+
+    // TODO: make sure this is saved properly in prod
+    secret: process.env.SESSION_SECRET,
     /* The `resave: true` option in the `session` middleware configuration indicates that the session
     data should be saved back to the session store even if the session was never modified during the
     request. */
-    resave: true,
+    resave: false,
     /* The `saveUninitialized: false` option in the `session` middleware configuration indicates that
     the session will not be saved for a session that is uninitialized. In other words, if a session
     is new and has not been modified during the request, it will not be saved to the session store. */
@@ -52,6 +54,7 @@ app.use(session({
         //maxAge: 5 * 60 * 60 * 24 * 1000, // 5 days
         /* The `secure: false` option within the `session` middleware configuration is used to specify
         whether the session cookie should be set with the `Secure` attribute or not. */
+        // TODO: probably should be true in production if we use http
         secure: false
     },
 }));

--- a/api/index.js
+++ b/api/index.js
@@ -19,6 +19,7 @@ const passportSetup = require("./passport-setup"); /// importing our student aut
 const experience_router = require("./routes/experiences"); /// importing our experience routes written in another file
 const User = require("./models/User");
 const feedbackRouter = require("./routes/feedback");
+const adminRouter = require("./routes/admin");
 /* 
 Status codes returned in the responses of various API endpoints are mostly in line with
 RESTFul API Practices
@@ -80,8 +81,8 @@ This middleware is used to parse incoming requests with JSON payloads. */
 
 app.use("/api/feedback", feedbackRouter);
 app.use("/api/experiences", experience_router); // Update the experiences route to include /api
+app.use("/api/admin", adminRouter); 
 
-/// Basic endpoint to see if our backend server is running without any complications
 app.get("/api", (req, res) => {
     try {
         return res.status(200).json("JSON Server is running");

--- a/api/models/Admin.js
+++ b/api/models/Admin.js
@@ -1,0 +1,17 @@
+const mongoose = require("mongoose");
+
+const adminSchema = new mongoose.Schema({
+    id: {
+        type: Number,
+        unique: true,
+        required: true,
+        increment: true
+    },
+    email: {
+        type: String,
+        unique: true,
+        required: true,
+    }, 
+}, { timestamps: true });
+
+module.exports = mongoose.model("Admin", adminSchema);

--- a/api/models/Admin.js
+++ b/api/models/Admin.js
@@ -1,5 +1,8 @@
 const mongoose = require("mongoose");
 
+/*
+* The `admins` collection will be used to store the admin users by email.
+*/
 const adminSchema = new mongoose.Schema({
     id: {
         type: Number,

--- a/api/routes/admin.js
+++ b/api/routes/admin.js
@@ -1,0 +1,33 @@
+const express = require("express");
+const router = express.Router();
+const AdminMod = require("../models/Admin");
+
+const isAdmin = async (req, res, next) => {
+    if(!req.isAuthenticated()){
+        throw new Error("User is not authenticated");
+    }
+
+    try{
+        const admin = await AdminMod.findOne({ email: req.user.email });
+        if(!admin){
+            throw new Error("User is not an admin");
+        }
+        next();
+    } 
+    catch(error){
+        res.status(400).json({
+            sucess: false,
+            message: error.message
+        });
+    }
+};
+
+router.get("/checkAdmin", isAdmin, (req, res) => {
+    res.status(200).json({
+        success: true,
+        message: "User is an admin",
+        user: req.user
+    });
+});
+
+model.exports = router;

--- a/api/routes/admin.js
+++ b/api/routes/admin.js
@@ -11,7 +11,7 @@ const isAdmin = async (req, res, next) => {
         if(!req.isAuthenticated()){
             throw new Error("User is not authenticated");
         }
-        const admin = await AdminMod.findOne({ email: req.user.email });
+        const admin = await AdminMod.findOne({ email: req.user.user.email });
         if(!admin){
             throw new Error("User is not an admin");
         }

--- a/api/routes/admin.js
+++ b/api/routes/admin.js
@@ -3,11 +3,10 @@ const router = express.Router();
 const AdminMod = require("../models/Admin");
 
 const isAdmin = async (req, res, next) => {
-    if(!req.isAuthenticated()){
-        throw new Error("User is not authenticated");
-    }
-
     try{
+        if(!req.isAuthenticated()){
+            throw new Error("User is not authenticated");
+        }
         const admin = await AdminMod.findOne({ email: req.user.email });
         if(!admin){
             throw new Error("User is not an admin");
@@ -16,7 +15,7 @@ const isAdmin = async (req, res, next) => {
     } 
     catch(error){
         res.status(400).json({
-            sucess: false,
+            success: false,
             message: error.message
         });
     }
@@ -30,4 +29,4 @@ router.get("/checkAdmin", isAdmin, (req, res) => {
     });
 });
 
-model.exports = router;
+module.exports = router;

--- a/api/routes/admin.js
+++ b/api/routes/admin.js
@@ -2,6 +2,10 @@ const express = require("express");
 const router = express.Router();
 const AdminMod = require("../models/Admin");
 
+/*
+* This function calls the next middleware only if the user is authenticated and is an admin.
+* It can be used to quickly check if the user is indeed an admin.
+*/
 const isAdmin = async (req, res, next) => {
     try{
         if(!req.isAuthenticated()){
@@ -21,6 +25,9 @@ const isAdmin = async (req, res, next) => {
     }
 };
 
+/*
+* This GET route responds successfully if the user is an admin.
+*/
 router.get("/checkAdmin", isAdmin, (req, res) => {
     res.status(200).json({
         success: true,

--- a/client/src/components/AdminDashboard.css
+++ b/client/src/components/AdminDashboard.css
@@ -2,3 +2,8 @@
     margin: 50px;
     margin-top: 20px;
 }
+
+.not-admin {
+    margin: 50px;
+    margin-top: 20px;
+}

--- a/client/src/components/AdminDashboard.jsx
+++ b/client/src/components/AdminDashboard.jsx
@@ -14,7 +14,7 @@ const AdminDashboard = () => {
 
   const checkAdminStatus = async () => {
       try{
-        const res = await fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:8000'}/checkAdmin`, {
+        const res = await fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:8000'}/api/admin/checkAdmin`, {
           method: "GET",
           credentials: "include"
         });

--- a/client/src/components/AdminDashboard.jsx
+++ b/client/src/components/AdminDashboard.jsx
@@ -12,6 +12,9 @@ const AdminDashboard = () => {
   const navigate = useNavigate();
   const [isAdmin, setIsAdmin] = useState(null);
 
+  /*
+  * This function polls the server to check if the user is an admin, and sets the isAdmin state accordingly.
+  */
   const checkAdminStatus = async () => {
       try{
         const res = await fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:8000'}/api/admin/checkAdmin`, {

--- a/client/src/components/AdminDashboard.jsx
+++ b/client/src/components/AdminDashboard.jsx
@@ -4,18 +4,42 @@ import { useNavigate } from 'react-router-dom';
 import './Experiences.css'; // For Experiences-specific styles
 import './AdminDashboard.css'; // For AdminDashboard-specific styles
 
+
 const AdminDashboard = () => {
   const [experiences, setExperiences] = useState([]);
   const user = useSelector((state) => state.auth.user);
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
+  const [isAdmin, setIsAdmin] = useState(null);
+
+  const checkAdminStatus = async () => {
+      try{
+        const res = await fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:8000'}/checkAdmin`, {
+          method: "GET",
+          credentials: "include"
+        });
+        const data = await res.json();
+        data.success ? setIsAdmin(true) : setIsAdmin(false);
+      } 
+      catch (error){
+        console.error("Error getting admin status:", error);
+        setIsAdmin(false);
+      }
+  };
 
   useEffect(() => {
-    if (user && !["dv22csb0f38","dp22csb0f23","sp22csb0f08"].includes(user.username)) { //change this later
-      // Redirect to home page if not admin
-      navigate("/");
-    }
-    // Fetch all experiences from the server
+    // I'll keep the emails here until admin works in prod 
+    // if (user && !["dv22csb0f38","dp22csb0f23","sp22csb0f08"].includes(user.username)) { //change this later
+    //   // Redirect to home page if not admin
+    //   navigate("/");
+    // }
+    //if (!user) return;
+    checkAdminStatus();
+
+  }, []);
+
+  useEffect(() => {
+    if (isAdmin !== true) return;
     const fetchExperiences = async () => {
       try {
         setLoading(true);
@@ -40,13 +64,21 @@ const AdminDashboard = () => {
       }
     };
     fetchExperiences();
-  }, []);
+  }, [isAdmin]);
 
+  if(isAdmin === false) {  
+    return (
+      <div className="not-admin">
+        <h1>Access Denied</h1>
+        <p>You do not have permission to view this page.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="admin-dash">
       <h1>Admin Dashboard</h1>
-      {loading ? (
+      {(loading || isAdmin === null) ? (
         <div>Loading...</div>
       ) : (
         <div className="experiences-results">

--- a/client/src/components/TopBar.jsx
+++ b/client/src/components/TopBar.jsx
@@ -146,21 +146,6 @@ function TopBar() {
                   )}
                 </span>
               </li>
-              {user ? (
-                <li>
-                  <span>
-                    <NavLink
-                      to="/admin"
-                      onClick={() => setMenuOpen(false)}
-                      className={({ isActive }) => (isActive ? "active" : "")}
-                    >
-                      Admin
-                    </NavLink>
-                  </span>
-                </li>
-              ) : (
-                ""
-              )}
               <li>
                 <NavLink
                   to="/search"


### PR DESCRIPTION
This PR adds a new collection  `admins` and confirms that the user is an admin by using a new endpoint `/checkAdmin`. As of now you would have to manually add admins into the collection, but they have only two fields, an id and an email. 

We also removed the admin navlink from the header (could add this back later and check for admin to display the admin option), so admins must manually navigate to `/admin` to get the admin dashboard. 

[breaking change] Finally we moved some configs of the express-session to env, so please add the following two env variables or the app will crash:
```
SESSION_SECRET=some_pass_you_guys_like
HTTPS=true # set this accordingly if the environment is using https or http
```

Suggestions and TODOs for the future:

- CRITICAL: currently no route that only an admin should have access to (like verifying experiences) is actually protected by an admin check. The entire admin dashboard is protected by an admin check which in turn affects a client state variable, which should ward off most people, but it is obviously necessary to perform the admin check within the backend whenever an admin-only route is called. This should be a quick fix however cuz anyway this PR includes an isAdmin middleware func, that we could just call for each admin-only route. (I'll probably do this by the time the task is due, if i identify all the admin-only routes).
