### PR TITLE
feat: task 6 (backend) add support for optional verdicts in backend

### DIFF
--- a/api/models/Experience.js
+++ b/api/models/Experience.js
@@ -23,7 +23,6 @@ const experienceSchema = new mongoose.Schema({
     type: String,
     enum: [
       "REJ_OT",    // Didn't get past OT
-      "SEL_OT",    // Got past OT
       "SEL_INT",   // Selected
       "REJ_INT",   // Rejected in interview
     ],

--- a/api/routes/experiences.js
+++ b/api/routes/experiences.js
@@ -116,7 +116,7 @@ router.post("/addExperience", async (req, res) => {
       return res.status(400).json({ error: true, message: 'All required fields must be filled.' });
     }
 
-    if(verdict && !["REJ_OT", "SEL_OT", "SEL_INT", "REJ_INT"].includes(verdict)){
+    if(verdict === null || (verdict && !["REJ_OT", "SEL_OT", "SEL_INT", "REJ_INT"].includes(verdict))){
       return res.status(400).json({ error: true, message: 'Invalid verdicts.' });
     }
 


### PR DESCRIPTION
This PR adds support for an optional verdicts enum containing:
```
"REJ_OT",    // Didn't get past OT
"SEL_INT",   // Selected
"REJ_INT",   // Rejected in interview
```

If more set verdicts or a custom verdict is required lmk here.