### PR TITLE
Fixed round description clearing upon submitting

### DIFF
--- a/client/src/components/AddExperience.jsx
+++ b/client/src/components/AddExperience.jsx
@@ -129,8 +129,9 @@ const AddExperience = ({ initialExperience, editMode, experienceId }) => {
   // Interview Rounds
   const handleRoundChange = (idx, field, value) => {
     setExperience((prev) => {
-      const updated = [...prev.interviewRounds];
-      updated[idx][field] = value;
+      const updated = prev.interviewRounds.map((round, i) =>
+        i === idx ? { ...round, [field]: value } : round
+      );
       return { ...prev, interviewRounds: updated };
     });
   };


### PR DESCRIPTION
Previously, the round description was not clearing when you submit an experience as React was not re-rendering the object, since the array was being changed in-place.