### PR TITLE
Fixed github typo

### DIFF
--- a/client/src/components/ExpPage.jsx
+++ b/client/src/components/ExpPage.jsx
@@ -152,7 +152,7 @@ const ExpPage = () => {
                 </p>
               )}
 
-              {expUser.github === "" || expUser.linkedIn === undefined ? (
+              {expUser.github === "" || expUser.github === undefined ? (
                 ""
               ) : (
                 <p>


### PR DESCRIPTION
The user info display section in ExpPage.jsx was comparing the linkedin and github side-by-side (typo). Changed to compare properly.